### PR TITLE
Silence noisy feed-io parser errors

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -15,6 +15,7 @@ namespace OCA\News\AppInfo;
 
 use FeedIo\Explorer;
 use FeedIo\FeedIo;
+use OCA\News\Log\FeedIoLogger;
 use HTMLPurifier;
 use HTMLPurifier_Config;
 use Favicon\Favicon;
@@ -134,12 +135,14 @@ class Application extends App implements IBootstrap
 
         $context->registerService(FeedIo::class, function (ContainerInterface $c): FeedIo {
             $config = $c->get(FetcherConfig::class);
-            return new FeedIo($config->getClient(), $c->get(LoggerInterface::class));
+            $logger = new FeedIoLogger($c->get(LoggerInterface::class));
+            return new FeedIo($config->getClient(), $logger);
         });
 
         $context->registerService(Explorer::class, function (ContainerInterface $c): Explorer {
             $config = $c->get(FetcherConfig::class);
-            return new Explorer($config->getClient(), $c->get(LoggerInterface::class));
+            $logger = new FeedIoLogger($c->get(LoggerInterface::class));
+            return new Explorer($config->getClient(), $logger);
         });
 
         $context->registerService(FaviconDataAccess::class, function (ContainerInterface $c): FaviconDataAccess {

--- a/lib/Log/FeedIoLogger.php
+++ b/lib/Log/FeedIoLogger.php
@@ -1,0 +1,29 @@
+<?php
+namespace OCA\News\Log;
+
+use Psr\Log\AbstractLogger;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
+
+/**
+ * Logger wrapper for feed-io to silence noisy messages.
+ */
+class FeedIoLogger extends AbstractLogger
+{
+    public function __construct(private LoggerInterface $logger)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function log($level, $message, array $context = []): void
+    {
+        if ($level === LogLevel::ERROR && $message === 'No parser can handle this stream') {
+            $this->logger->debug($message, $context);
+            return;
+        }
+
+        $this->logger->log($level, $message, $context);
+    }
+}

--- a/tests/Unit/Log/FeedIoLoggerTest.php
+++ b/tests/Unit/Log/FeedIoLoggerTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace OCA\News\Tests\Unit\Log;
+
+use OCA\News\Log\FeedIoLogger;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+class FeedIoLoggerTest extends TestCase
+{
+    public function testDowngradesSpecificError(): void
+    {
+        /** @var LoggerInterface|MockObject $inner */
+        $inner = $this->createMock(LoggerInterface::class);
+
+        $inner->expects($this->never())
+            ->method('error');
+        $inner->expects($this->once())
+            ->method('debug')
+            ->with('No parser can handle this stream', []);
+
+        $logger = new FeedIoLogger($inner);
+        $logger->error('No parser can handle this stream');
+    }
+
+    public function testPassesOtherMessages(): void
+    {
+        /** @var LoggerInterface|MockObject $inner */
+        $inner = $this->createMock(LoggerInterface::class);
+
+        $inner->expects($this->once())
+            ->method('error')
+            ->with('Something else', []);
+
+        $logger = new FeedIoLogger($inner);
+        $logger->error('Something else');
+    }
+}


### PR DESCRIPTION
## Summary
- wrap Nextcloud logger with FeedIoLogger to downgrade feed-io parser errors
- apply FeedIoLogger to FeedIo and Explorer services
- test FeedIoLogger behavior

## Testing
- `npm test`
- `./vendor/phpunit/phpunit/phpunit -c phpunit.xml` *(fails: bootstrap file missing)*
- `./vendor/bin/phpcs --standard=PSR2 --ignore=lib/Migration/Version*.php lib`
- `./vendor/bin/phpstan analyse --level=1 lib` *(fails: Bootstrap file ... does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_689b59a65724833087391011b8bded12