### PR TITLE
Silence noisy feed-io parser errors and deprecations

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -15,6 +15,7 @@ namespace OCA\News\AppInfo;
 
 use FeedIo\Explorer;
 use FeedIo\FeedIo;
+use OCA\News\Log\FeedIoLogger;
 use HTMLPurifier;
 use HTMLPurifier_Config;
 use Favicon\Favicon;
@@ -134,12 +135,14 @@ class Application extends App implements IBootstrap
 
         $context->registerService(FeedIo::class, function (ContainerInterface $c): FeedIo {
             $config = $c->get(FetcherConfig::class);
-            return new FeedIo($config->getClient(), $c->get(LoggerInterface::class));
+            $logger = new FeedIoLogger($c->get(LoggerInterface::class));
+            return new FeedIo($config->getClient(), $logger);
         });
 
         $context->registerService(Explorer::class, function (ContainerInterface $c): Explorer {
             $config = $c->get(FetcherConfig::class);
-            return new Explorer($config->getClient(), $c->get(LoggerInterface::class));
+            $logger = new FeedIoLogger($c->get(LoggerInterface::class));
+            return new Explorer($config->getClient(), $logger);
         });
 
         $context->registerService(FaviconDataAccess::class, function (ContainerInterface $c): FaviconDataAccess {

--- a/lib/Log/FeedIoLogger.php
+++ b/lib/Log/FeedIoLogger.php
@@ -1,0 +1,29 @@
+<?php
+namespace OCA\News\Log;
+
+use Psr\Log\AbstractLogger;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
+
+/**
+ * Logger wrapper for feed-io to silence noisy messages.
+ */
+class FeedIoLogger extends AbstractLogger
+{
+    public function __construct(private LoggerInterface $logger)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function log($level, $message, array $context = []): void
+    {
+        if ($level === LogLevel::ERROR && $message === 'No parser can handle this stream') {
+            $this->logger->debug($message, $context);
+            return;
+        }
+
+        $this->logger->log($level, $message, $context);
+    }
+}

--- a/tests/Unit/Log/FeedIoLoggerTest.php
+++ b/tests/Unit/Log/FeedIoLoggerTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace OCA\News\Tests\Unit\Log;
+
+use OCA\News\Log\FeedIoLogger;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+class FeedIoLoggerTest extends TestCase
+{
+    public function testDowngradesSpecificError(): void
+    {
+        /** @var LoggerInterface|MockObject $inner */
+        $inner = $this->createMock(LoggerInterface::class);
+
+        $inner->expects($this->never())
+            ->method('error');
+        $inner->expects($this->once())
+            ->method('debug')
+            ->with('No parser can handle this stream', []);
+
+        $logger = new FeedIoLogger($inner);
+        $logger->error('No parser can handle this stream');
+    }
+
+    public function testPassesOtherMessages(): void
+    {
+        /** @var LoggerInterface|MockObject $inner */
+        $inner = $this->createMock(LoggerInterface::class);
+
+        $inner->expects($this->once())
+            ->method('error')
+            ->with('Something else', []);
+
+        $logger = new FeedIoLogger($inner);
+        $logger->error('Something else');
+    }
+}

--- a/vendor/php-feed-io/feed-io/src/FeedIo/Explorer.php
+++ b/vendor/php-feed-io/feed-io/src/FeedIo/Explorer.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FeedIo;
+
+use DateTime;
+use DomDocument;
+use DomElement;
+use FeedIo\Adapter\ClientInterface;
+use Psr\Log\LoggerInterface;
+
+class Explorer
+{
+    public const VALID_TYPES = [
+        'application/atom+xml',
+        'application/rss+xml'
+    ];
+
+    public function __construct(
+        protected ClientInterface $client,
+        protected LoggerInterface $logger
+    ) {
+    }
+
+    public function discover(string $url): array
+    {
+        $this->logger->info("discover feeds from {$url}");
+        $stream = $this->client->getResponse($url, new DateTime('@0'));
+
+        $internalErrors = libxml_use_internal_errors(true);
+        $feeds = $this->extractFeeds($stream->getBody(), $url);
+
+        libxml_use_internal_errors($internalErrors);
+
+        return $feeds;
+    }
+
+    protected function extractFeeds(string $html, ?string $url = null): array
+    {
+        $dom = new DOMDocument();
+        $dom->loadHTML($html);
+
+        $links = $dom->getElementsByTagName('link');
+        $feeds = [];
+        foreach ($links as $link) {
+            if ($this->isFeedLink($link)) {
+                $href = $link->getAttribute('href');
+                if (strpos($href, '//') === 0) {
+                    // Link href is protocol-less, Implies feed supports http
+                    // and https. Consumers will often assume that feed url
+                    // includes protocol, so we will assign a protocol before
+                    // returning
+                    $href = 'https:' . $href;
+                }
+                if (!parse_url($href, PHP_URL_HOST) && $url){
+                    $href = parse_url($url, PHP_URL_SCHEME) . '://' . parse_url($url, PHP_URL_HOST) . '/' . ltrim($href,'/');
+                }
+                $feeds[] = $href;
+            }
+        }
+
+        return $feeds;
+    }
+
+    protected function isFeedLink(DomElement $element): bool
+    {
+        return $element->hasAttribute('type')
+                && in_array($element->getAttribute('type'), self::VALID_TYPES);
+    }
+}


### PR DESCRIPTION
## Summary
- wrap Nextcloud logger with FeedIoLogger to downgrade feed-io parser errors
- apply FeedIoLogger to FeedIo and Explorer services
- test FeedIoLogger behavior
- mark Explorer::extractFeeds URL parameter explicitly nullable to avoid deprecation

## Testing
- `npm test`
- `./vendor/phpunit/phpunit/phpunit -c phpunit.xml` *(fails: Error in bootstrap script)*
- `./vendor/bin/phpcs --standard=PSR2 --ignore=lib/Migration/Version*.php lib`
- `./vendor/bin/phpstan analyse --level=1 lib` *(fails: Bootstrap file /workspace/news/../../lib/base.php does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_689b59a65724833087391011b8bded12